### PR TITLE
Add GitHub release payload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ or
 girokmoji TEST_PROJECT_NAME 2025-02-10 test_repository_dir v0.1.0 v0.5.2 > release_note.md
 ```
 
+### GitHub Release payload
+
+To create JSON payload for GitHub Release:
+
+```bash
+girokmoji TEST_PROJECT_NAME 2025-02-10 test_repository_dir v0.1.0 v0.5.2 --github-payload > release.json
+```
+
 ## Example
 
 For generated release note, go [EXAMPLE.md](./EXAMPLE.md)

--- a/girokmoji/__init__.py
+++ b/girokmoji/__init__.py
@@ -1,0 +1,1 @@
+from .changelog import change_log, github_release_payload

--- a/girokmoji/__main__.py
+++ b/girokmoji/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from girokmoji.changelog import change_log
+from girokmoji.changelog import change_log, github_release_payload
 
 
 parser = argparse.ArgumentParser(
@@ -18,15 +18,31 @@ parser.add_argument(
     help="Optional version string (defaults to head_tag if not provided)",
     default=None,
 )
+parser.add_argument(
+    "--github-payload",
+    action="store_true",
+    help="Output GitHub Release payload JSON instead of markdown",
+)
 
 args = parser.parse_args()
 
-changelog = change_log(
-    project_name=args.project_name,
-    release_date=args.release_date,
-    repo_dir=args.repo_dir,
-    tail_tag=args.tail_tag,
-    head_tag=args.head_tag,
-    version=args.version,
-)
-print(changelog, file=sys.stdout)
+if args.github_payload:
+    payload = github_release_payload(
+        project_name=args.project_name,
+        release_date=args.release_date,
+        repo_dir=args.repo_dir,
+        tail_tag=args.tail_tag,
+        head_tag=args.head_tag,
+        version=args.version,
+    )
+    print(payload, file=sys.stdout)
+else:
+    changelog = change_log(
+        project_name=args.project_name,
+        release_date=args.release_date,
+        repo_dir=args.repo_dir,
+        tail_tag=args.tail_tag,
+        head_tag=args.head_tag,
+        version=args.version,
+    )
+    print(changelog, file=sys.stdout)

--- a/girokmoji/changelog.py
+++ b/girokmoji/changelog.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Iterable
+import json
 
 from pygit2 import Commit
 
@@ -120,3 +121,33 @@ def change_log(
         release_date,
         structured_changelog(get_tag_to_tag_commits(repo_dir, tail_tag, head_tag)),
     ).strip()
+
+
+def github_release_payload(
+    project_name: str,
+    release_date: str,
+    repo_dir: Path,
+    tail_tag: str,
+    head_tag: str,
+    version: str | None = None,
+    *,
+    draft: bool = False,
+    prerelease: bool = False,
+) -> str:
+    """Return GitHub release payload as JSON string."""
+    changelog = change_log(
+        project_name=project_name,
+        release_date=release_date,
+        repo_dir=repo_dir,
+        tail_tag=tail_tag,
+        head_tag=head_tag,
+        version=version,
+    )
+    payload = {
+        "tag_name": head_tag,
+        "name": version or head_tag,
+        "body": changelog,
+        "draft": draft,
+        "prerelease": prerelease,
+    }
+    return json.dumps(payload)


### PR DESCRIPTION
## Summary
- output GitHub release payload via `github_release_payload`
- allow CLI option `--github-payload` to output JSON
- document GitHub release payload usage in README

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `python -m pytest -q` *(fails: No module named pytest)*