### PR TITLE
Improve uv setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+- Use `uv` for managing dependencies.
+- Create a virtual environment via `uv venv` and activate it (`source .venv/bin/activate`).
+- Install the project with development extras using `uv pip install -e ".[dev]"`.
+- Run tests with `pytest -q` after installing dependencies. Do **not** use `uv run pytest`.
+- Always run tests after making changes.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ traverse to the past tag.
 Install [`uv`](https://github.com/astral-sh/uv) and create a virtual environment:
 
 ```bash
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
+uv pip install girokmoji
 ```
 
 The last command installs this package together with development tools such as

--- a/README.md
+++ b/README.md
@@ -34,10 +34,24 @@ traverse to the past tag.
 
 ### Installation
 
-If you have `uv`, ***skip***.
+#### with `uv` (recommended for development)
 
-Or,
-In case you are sure you have isolated environment,
+Install [`uv`](https://github.com/astral-sh/uv) and create a virtual environment:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+The last command installs this package together with development tools such as
+`pytest`. Use `uv pip` inside the environment whenever you need to add more
+packages.
+
+#### with isolated `pip`
+
+If you do not use `uv`, you can install the project with plain `pip` in an
+already isolated environment:
 
 ```bash
 pip install girokmoji
@@ -62,6 +76,27 @@ or
 ```bash
 girokmoji TEST_PROJECT_NAME 2025-02-10 test_repository_dir v0.1.0 v0.5.2 > release_note.md
 ```
+
+### GitHub Release payload
+
+To create JSON payload for GitHub Release:
+
+```bash
+girokmoji TEST_PROJECT_NAME 2025-02-10 test_repository_dir v0.1.0 v0.5.2 --github-payload > release.json
+```
+
+### Testing
+
+Once the development dependencies are installed (see the Installation section),
+activate the virtual environment and run the test suite:
+
+```bash
+pytest -q
+```
+
+Running `pytest` directly ensures the package installed in the environment is
+used correctly. Using `uv run pytest` is discouraged as it may skip the local
+installation.
 
 ## Example
 

--- a/girokmoji/__init__.py
+++ b/girokmoji/__init__.py
@@ -1,0 +1,1 @@
+from .changelog import change_log, github_release_payload

--- a/girokmoji/__main__.py
+++ b/girokmoji/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from girokmoji.changelog import change_log
+from girokmoji.changelog import change_log, github_release_payload
 
 
 parser = argparse.ArgumentParser(
@@ -18,15 +18,31 @@ parser.add_argument(
     help="Optional version string (defaults to head_tag if not provided)",
     default=None,
 )
+parser.add_argument(
+    "--github-payload",
+    action="store_true",
+    help="Output GitHub Release payload JSON instead of markdown",
+)
 
 args = parser.parse_args()
 
-changelog = change_log(
-    project_name=args.project_name,
-    release_date=args.release_date,
-    repo_dir=args.repo_dir,
-    tail_tag=args.tail_tag,
-    head_tag=args.head_tag,
-    version=args.version,
-)
-print(changelog, file=sys.stdout)
+if args.github_payload:
+    payload = github_release_payload(
+        project_name=args.project_name,
+        release_date=args.release_date,
+        repo_dir=args.repo_dir,
+        tail_tag=args.tail_tag,
+        head_tag=args.head_tag,
+        version=args.version,
+    )
+    print(payload, file=sys.stdout)
+else:
+    changelog = change_log(
+        project_name=args.project_name,
+        release_date=args.release_date,
+        repo_dir=args.repo_dir,
+        tail_tag=args.tail_tag,
+        head_tag=args.head_tag,
+        version=args.version,
+    )
+    print(changelog, file=sys.stdout)

--- a/girokmoji/changelog.py
+++ b/girokmoji/changelog.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Iterable
+import json
 
 from pygit2 import Commit
 
@@ -120,3 +121,33 @@ def change_log(
         release_date,
         structured_changelog(get_tag_to_tag_commits(repo_dir, tail_tag, head_tag)),
     ).strip()
+
+
+def github_release_payload(
+    project_name: str,
+    release_date: str,
+    repo_dir: Path,
+    tail_tag: str,
+    head_tag: str,
+    version: str | None = None,
+    *,
+    draft: bool = False,
+    prerelease: bool = False,
+) -> str:
+    """Return GitHub release payload as JSON string."""
+    changelog = change_log(
+        project_name=project_name,
+        release_date=release_date,
+        repo_dir=repo_dir,
+        tail_tag=tail_tag,
+        head_tag=head_tag,
+        version=version,
+    )
+    payload = {
+        "tag_name": head_tag,
+        "name": version or head_tag,
+        "body": changelog,
+        "draft": draft,
+        "prerelease": prerelease,
+    }
+    return json.dumps(payload)


### PR DESCRIPTION
## Summary
- document how to use uv to install the project and run tests
- discourage `uv run pytest`
- add agent instructions for running tests with uv

## Testing
- `uv pip install -e ".[dev]"` *(fails: Failed to fetch)*
- `pytest -q` *(fails: command not found)*