### PR TITLE
Make tags great again

### DIFF
--- a/girokmoji/__main__.py
+++ b/girokmoji/__main__.py
@@ -5,44 +5,54 @@ from pathlib import Path
 from girokmoji.changelog import change_log, github_release_payload
 
 
-parser = argparse.ArgumentParser(
-    description="Generate a changelog from gitmoji-based commits between two tags."
-)
-parser.add_argument("project_name", help="Name of the project")
-parser.add_argument("release_date", help="Release date (YYYY-MM-DD)")
-parser.add_argument("repo_dir", type=Path, help="Path to the git repository")
-parser.add_argument("tail_tag", help="Older git tag (tail tag)")
-parser.add_argument("head_tag", help="Newer git tag (head tag)")
-parser.add_argument(
-    "--version",
-    help="Optional version string (defaults to head_tag if not provided)",
-    default=None,
-)
-parser.add_argument(
-    "--github-payload",
-    action="store_true",
-    help="Output GitHub Release payload JSON instead of markdown",
-)
-
-args = parser.parse_args()
-
-if args.github_payload:
-    payload = github_release_payload(
-        project_name=args.project_name,
-        release_date=args.release_date,
-        repo_dir=args.repo_dir,
-        tail_tag=args.tail_tag,
-        head_tag=args.head_tag,
-        version=args.version,
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a changelog from gitmoji-based commits between two tags."
     )
-    print(payload, file=sys.stdout)
-else:
-    changelog = change_log(
-        project_name=args.project_name,
-        release_date=args.release_date,
-        repo_dir=args.repo_dir,
-        tail_tag=args.tail_tag,
-        head_tag=args.head_tag,
-        version=args.version,
+    parser.add_argument("project_name", help="Name of the project")
+    parser.add_argument("release_date", help="Release date (YYYY-MM-DD)")
+    parser.add_argument("repo_dir", type=Path, help="Path to the git repository")
+    parser.add_argument("tail_tag", help="Older git tag (tail tag)")
+    parser.add_argument("head_tag", help="Newer git tag (head tag)")
+    parser.add_argument(
+        "--release-version",
+        dest="version",
+        help="Optional release version string (defaults to head_tag)",
+        default=None,
     )
-    print(changelog, file=sys.stdout)
+    parser.add_argument(
+        "--github-payload",
+        action="store_true",
+        help="Output GitHub Release payload JSON instead of markdown",
+    )
+
+    args = parser.parse_args()
+
+    if args.github_payload:
+        payload = github_release_payload(
+            project_name=args.project_name,
+            release_date=args.release_date,
+            repo_dir=args.repo_dir,
+            tail_tag=args.tail_tag,
+            head_tag=args.head_tag,
+            version=args.version,
+        )
+        print(payload, file=sys.stdout)
+    else:
+        changelog = change_log(
+            project_name=args.project_name,
+            release_date=args.release_date,
+            repo_dir=args.repo_dir,
+            tail_tag=args.tail_tag,
+            head_tag=args.head_tag,
+            version=args.version,
+        )
+        print(changelog, file=sys.stdout)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pragma: no cover - top level entry
+        print(exc, file=sys.stderr)
+        sys.exit(1)

--- a/girokmoji/git.py
+++ b/girokmoji/git.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import Iterable
 
-from pygit2 import Commit, Repository, GIT_SORT_TOPOLOGICAL
+from pygit2 import Commit, Repository, GIT_SORT_TOPOLOGICAL, discover_repository
+from pygit2.enums import ObjectType
 
 from girokmoji.exception import NoSuchTagFoundError
 
@@ -9,15 +10,19 @@ from girokmoji.exception import NoSuchTagFoundError
 def get_tag_to_tag_commits(
     repo_dir: Path, tail_tag: str, head_tag: str
 ) -> Iterable[Commit]:
-    repo = Repository(str(repo_dir))
-    head = repo.references.get(f"refs/tags/{head_tag}")
-    tail = repo.references.get(f"refs/tags/{tail_tag}")
-    if head is None:
+    repo = Repository(discover_repository(str(repo_dir)))
+    head_ref = repo.references.get(f"refs/tags/{head_tag}")
+    tail_ref = repo.references.get(f"refs/tags/{tail_tag}")
+    if head_ref is None:
         raise NoSuchTagFoundError(f"{head_tag} can't be found")
-    if tail is None:
+    if tail_ref is None:
         raise NoSuchTagFoundError(f"{tail_tag} can't be found")
-    rev_walk = repo.walk(head.target, GIT_SORT_TOPOLOGICAL)
-    rev_walk.hide(tail.target)
+
+    head_commit = repo[head_ref.target].peel(ObjectType.COMMIT)
+    tail_commit = repo[tail_ref.target].peel(ObjectType.COMMIT)
+
+    rev_walk = repo.walk(head_commit.id, GIT_SORT_TOPOLOGICAL)
+    rev_walk.hide(tail_commit.id)
     for rev in rev_walk:
         if isinstance(rev, Commit):
             yield rev


### PR DESCRIPTION
## Summary
- rename `--version` CLI option to `--release-version` to avoid confusion with program version

## Testing
- `uv venv`
- `uv sync`
- `.venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844eb898308832d8449c6e4e5891c15