### PR TITLE
Keep release notes tidy with grouped gitmoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ uv sync
 # run the test suite
 uv run pytest
 ```
+See [multiline commit test](docs/multiline_commit_test.md) for multi-line commit examples and how commits are grouped in release notes.

--- a/RELEASE_NOTE_LONG.md
+++ b/RELEASE_NOTE_LONG.md
@@ -1,0 +1,45 @@
+# 🚀 **Girokmoji** Release Changelog v0.5.7
+
+
+_"Change is always thrilling!"_  
+_(And sometimes a little confusing.)_
+    
+
+**Release Date:** 2025-02-10
+
+
+---
+
+
+## Documentation and Comment
+
+**Documentation and comments are the developer’s conscience.**
+
+- **📝 Add or update documentation.**
+  - [*Expand multiline commit doc*](../../commit/4665fe6f034ceb5c444ae5f3f377c5bd800c03cc)
+  - [*Reference multiline commit doc*](../../commit/7576d0937b0de5d41dfd78ff1b8de8253a732eff)
+  - [*Add multiline commit test doc*](../../commit/286559ccd322ea851d74d65688c648fba0a8c451)
+  - [*Fix README markdown formatting*](../../commit/30512ed131b5a6c0a100d1c74ea54ac0e0b12969)
+  - [*meaningful guide document*](../../commit/b212f3ba59420feb3c2b7da61b6c761b23812a01)
+
+---
+
+
+## Test
+
+**Tests provide our code with the stability it deserves.**
+
+- **✅ Add, update, or pass tests.**
+  - [*add tests for full coverage*](../../commit/266081365ce8c2b9ed78e5817e6c1284fcb7df93)
+
+---
+
+
+## Code Maintenance and Refactoring
+
+**Time to tidy up the code and say goodbye to technical debt.**
+
+- **♻️ Refactor code.**
+  - [*rename version arg*](../../commit/f77bdd857e06410562bed2c753e90e1471ae3e63)
+
+---

--- a/docs/multiline_commit_test.md
+++ b/docs/multiline_commit_test.md
@@ -1,0 +1,8 @@
+# Multiline Commit Test
+
+This file exists to test release note generation with commits that have multiple lines in their commit messages.
+
+- This bullet will help test point 1
+- Another bullet for release note parsing
+
+Release notes now group repeated gitmoji entries under a single header, keeping lists concise.

--- a/girokmoji/template.py
+++ b/girokmoji/template.py
@@ -91,6 +91,42 @@ class DefaultEntry(Entry):
         )
 
 
+@dataclass
+class EntryGroupHeader(SupportTemplate):
+    emoji: str
+    gitmoji_description: str
+
+
+class DefaultEntryGroupHeader(EntryGroupHeader):
+    markdown_template: ClassVar[str] = "- **$emoji $gitmoji_description**\n"
+
+    @property
+    def markdown(self):
+        return Template(self.markdown_template).substitute(
+            emoji=self.emoji,
+            gitmoji_description=self.gitmoji_description,
+        )
+
+
+@dataclass
+class EntrySubItem(SupportTemplate):
+    commit_description: str
+    commit_hash: str
+
+
+class DefaultEntrySubItem(EntrySubItem):
+    markdown_template: ClassVar[str] = (
+        "  - [*$commit_description*](../../commit/$commit_hash)\n"
+    )
+
+    @property
+    def markdown(self):
+        return Template(self.markdown_template).substitute(
+            commit_description=self.commit_description,
+            commit_hash=self.commit_hash,
+        )
+
+
 class DefaultSeparator(Separator):
     markdown_template: ClassVar[str] = """
 ---
@@ -105,4 +141,6 @@ class DefaultSeparator(Separator):
 HEAD = DefaultHead
 CATEGORY_SECTION = DefaultCategorySection
 ENTRY = DefaultEntry
+ENTRY_GROUP_HEADER = DefaultEntryGroupHeader
+ENTRY_SUBITEM = DefaultEntrySubItem
 SEPARATOR = DefaultSeparator

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -35,7 +35,7 @@ def test_get_category_and_sep_title():
 
 
 def test_structured_and_markdown(monkeypatch):
-    commits = [FakeCommit(":sparkles: feat"), FakeCommit(":bug: fix")]
+    commits = [FakeCommit(":sparkles: first"), FakeCommit(":sparkles: second")]
     structured = changelog.structured_changelog(commits)
     assert structured[catgitmoji.by_code()[":sparkles:"].category][0] is commits[0]
 
@@ -44,7 +44,8 @@ def test_structured_and_markdown(monkeypatch):
     monkeypatch.setattr(changelog, "get_tag_to_tag_commits", fake_get_tag_to_tag_commits)
 
     md = changelog.change_log("proj", "2024-01-01", Path("."), "v0", "v1")
-    assert "proj" in md
+    assert md.count("Introduce new features.") == 1
+    assert "first" in md and "second" in md
     payload = json.loads(
         changelog.github_release_payload("proj", "2024-01-01", Path("."), "v0", "v1")
     )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -18,5 +18,12 @@ def test_templates():
         commit_hash="abc",
     )
     assert "abc" in entry.markdown
+    header = template.ENTRY_GROUP_HEADER(
+        emoji="🐛",
+        gitmoji_description="bug",
+    )
+    assert "bug" in header.markdown
+    sub = template.ENTRY_SUBITEM(commit_description="fix", commit_hash="abc")
+    assert "fix" in sub.markdown
     sep = template.SEPARATOR()
     assert "---" in sep.markdown


### PR DESCRIPTION
## Summary
- group commits by gitmoji when rendering changelog
- adjust templates and docs for new nested layout
- show example of grouped release notes
- update tests for new markdown structure

## Testing
- `uv venv`
- `uv sync`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844fa5d58d4832d8c80a23fceeabca9