### PR TITLE
Give the release workflow a nudge

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish"
+        required: false
     
 
 permissions:
@@ -23,6 +27,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -105,3 +105,9 @@ uv sync
 uv run pytest
 ```
 See [multiline commit test](docs/multiline_commit_test.md) for multi-line commit examples and how commits are grouped in release notes.
+
+## Publishing to PyPI
+
+The "Publish Python Package to PyPI" workflow can be dispatched manually. Provide the
+`tag` input to select which release tag should be built and uploaded. The workflow
+checks out the chosen tag, runs tests, builds the package and then deploys it to PyPI.


### PR DESCRIPTION
## Summary
- allow PyPI workflow to accept a `tag` input when dispatched manually
- update checkout to use the selected tag
- document how to trigger a tagged publish

## Testing
- `uv venv`
- `uv sync`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845245dae58832d87c85110904c8987