### PR TITLE
Show me the version! CLI flag added

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ or
 girokmoji TEST_PROJECT_NAME 2025-02-10 test_repository_dir v0.1.0 v0.5.2 > release_note.md
 ```
 
+### Show version
+
+```bash
+girokmoji --version
+```
+
 ### GitHub Release payload
 
 To create JSON payload for GitHub Release:

--- a/girokmoji/__init__.py
+++ b/girokmoji/__init__.py
@@ -1,4 +1,13 @@
 """girokmoji package."""
 
+from importlib import metadata
+
 from .changelog import change_log as change_log
 from .changelog import github_release_payload as github_release_payload
+
+try:  # pragma: no cover - package might not be installed in tests
+    __version__ = metadata.version(__package__ or "girokmoji")
+except metadata.PackageNotFoundError:  # pragma: no cover - fallback version
+    __version__ = "0.0.0"
+
+__all__ = ["change_log", "github_release_payload", "__version__"]

--- a/girokmoji/__main__.py
+++ b/girokmoji/__main__.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 from girokmoji.changelog import change_log, github_release_payload
+from girokmoji import __version__
 
 
 def main() -> None:
@@ -24,6 +25,12 @@ def main() -> None:
         "--github-payload",
         action="store_true",
         help="Output GitHub Release payload JSON instead of markdown",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show program's version number and exit",
     )
 
     args = parser.parse_args()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+
+import girokmoji
+
+
+def test_cli_version():
+    result = subprocess.run(
+        [sys.executable, '-m', 'girokmoji', '--version'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert girokmoji.__version__ in result.stdout


### PR DESCRIPTION
## Summary
- expose package version information
- add `--version` CLI flag
- document how to check the version
- test the new CLI flag

## Testing
- `uv venv`
- `uv sync`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561462fb18832dae546c963881ef60